### PR TITLE
Padronização do First Things First

### DIFF
--- a/docs/base/requisitos/priorizacao/first-things-first.md
+++ b/docs/base/requisitos/priorizacao/first-things-first.md
@@ -7,27 +7,29 @@ Para a classificação dos benefícios, custo, valor e riscos dos requisitos fun
 
 ## Requisitos Funcionais
 
+A tabela a seguir detalha e identifica os requisitos funcionais que foram elicitados, seus custos, valor, risco, e também a prioridade baseada no artefato [Moscow](./moscow.md) que também foi realizado pela equipe e que juntamente com o First-Things-First auxilia na priorização dos requisitos.
+
 |         | Peso                                                                            | 2                  | 3                 |             |         | 1              |         | 1              |         |            |
 | ------- | ------------------------------------------------------------------------------- | ------------------ | ----------------- | ----------- | ------- | -------------- | ------- | -------------- | ------- | ---------- |
 | ID      | Requisitos                                                                      | Benefício relativo | Penalidade relativa | Valor Total | Valor % | Custo relativo | Custo % | Risco Relativo | Risco % | Prioridade |
-| REQB_01 | Ter sistema de comunicação entre responsáveis e professores.                    | 6,5                | 5                 | 28          | 6,69%   | 8              | 9,47%   | 4              | 8,89%   | 0,364      |
-| REQB_02 | Ter sistema de comunicação entre responsáveis e administradores da instituição. | 4,5                | 3                 | 18          | 4,30%   | 8              | 9,47%   | 5              | 11,11%  | 0,209      |
-| REQB_03 | Responsáveis receberem notificações sobre novas atividades.                     | 7                  | 2                 | 20          | 4,78%   | 4              | 4,73%   | 5              | 11,11%  | 0,302      |
-| REQB_04 | Responsáveis receberem notificações sobre entrada e saída da crianças.          | 6                  | 2                 | 18          | 4,30%   | 8,5            | 10,06%  | 7              | 15,56%  | 0,268      |
-| REQD_05 | Responsáveis receberem notificações sobre novos eventos.                        | 6                  | 1,5               | 16,5        | 3,94%   | 4              | 4,73%   | 5              | 11,11%  | 0,249      |
-| REQB_06 | Administrador poder criar e configurar turmas.                                  | 9                  | 9                 | 45          | 10,75%  | 6              | 7,10%   | 1              | 2,22%   | 1,153      |
-| REQB_07 | Administrador poder registras as crianças.                                      | 9                  | 9                 | 45          | 10,75%  | 4              | 4,73%   | 1              | 2,22%   | 1,546      |
-| REQB_08 | Administrador poder registrar os professores.                                   | 9                  | 9                 | 45          | 10,75%  | 4              | 4,73%   | 1              | 2,22%   | 1,546      |
-| REQB_09 | Administrador poder criar e configurar eventos.                                 | 7                  | 3                 | 23          | 5,50%   | 6              | 7,10%   | 3              | 6,67%   | 0,399      |
-| REQB_10 | Poder disponibilizar relatórios gerais.                                         | 6                  | 3                 | 21          | 5,02%   | 6              | 7,10%   | 4              | 8,89%   | 0,314      |
-| REQB_11 | Responsáveis terem acesso as informações e dados de suas crianças.             | 9                  | 9                 | 45          | 10,75%  | 7              | 8,28%   | 1              | 2,22%   | 1,023      |
-| REQB_12 | Professor poder registrar e gerenciar atividades.                                | 9                  | 8                 | 42          | 10,04%  | 6              | 7,10%   | 1              | 2,22%   | 1,076      |
-| REQB_13 | Professor poder lançar presença.                                                | 7                  | 3                 | 23          | 5,50%   | 6              | 7,10%   | 4              | 8,89%   | 0,344      |
-| REQB_14 | Professor poder notificar responsáveis com observações.                         | 7                  | 5                 | 29          | 6,93%   | 7              | 8,28%   | 3              | 6,67%   | 0,463      |
+| RF_01 | Ter sistema de comunicação entre responsáveis e professores.                    | 6,5                | 5                 | 28          | 6,69%   | 8              | 9,47%   | 4              | 8,89%   | 0,364      |
+| RF_02 | Ter sistema de comunicação entre responsáveis e administradores da instituição. | 4,5                | 3                 | 18          | 4,30%   | 8              | 9,47%   | 5              | 11,11%  | 0,209      |
+| RF_03 | Responsáveis receberem notificações sobre novas atividades.                     | 7                  | 2                 | 20          | 4,78%   | 4              | 4,73%   | 5              | 11,11%  | 0,302      |
+| RF_04 | Responsáveis receberem notificações sobre entrada e saída da crianças.          | 6                  | 2                 | 18          | 4,30%   | 8,5            | 10,06%  | 7              | 15,56%  | 0,268      |
+| RF_05 | Responsáveis receberem notificações sobre novos eventos.                        | 6                  | 1,5               | 16,5        | 3,94%   | 4              | 4,73%   | 5              | 11,11%  | 0,249      |
+| RF_06 | Administrador poder criar e configurar turmas.                                  | 9                  | 9                 | 45          | 10,75%  | 6              | 7,10%   | 1              | 2,22%   | 1,153      |
+| RF_07 | Administrador poder registras as crianças.                                      | 9                  | 9                 | 45          | 10,75%  | 4              | 4,73%   | 1              | 2,22%   | 1,546      |
+| RF_08 | Administrador poder registrar os professores.                                   | 9                  | 9                 | 45          | 10,75%  | 4              | 4,73%   | 1              | 2,22%   | 1,546      |
+| RF_09 | Administrador poder criar e configurar eventos.                                 | 7                  | 3                 | 23          | 5,50%   | 6              | 7,10%   | 3              | 6,67%   | 0,399      |
+| RF_10 | Poder disponibilizar relatórios gerais.                                         | 6                  | 3                 | 21          | 5,02%   | 6              | 7,10%   | 4              | 8,89%   | 0,314      |
+| RF_11 | Responsáveis terem acesso as informações e dados de suas crianças.             | 9                  | 9                 | 45          | 10,75%  | 7              | 8,28%   | 1              | 2,22%   | 1,023      |
+| RF_12 | Professor poder registrar e gerenciar atividades.                                | 9                  | 8                 | 42          | 10,04%  | 6              | 7,10%   | 1              | 2,22%   | 1,076      |
+| RF_13 | Professor poder lançar presença.                                                | 7                  | 3                 | 23          | 5,50%   | 6              | 7,10%   | 4              | 8,89%   | 0,344      |
+| RF_14 | Professor poder notificar responsáveis com observações.                         | 7                  | 5                 | 29          | 6,93%   | 7              | 8,28%   | 3              | 6,67%   | 0,463      |
 |         | TOTAL                                                                           | 102                | 71,5              | 418,5       | 10,00%  | 84,5           | 100,00% | 45             | 100,00% |            |
 
 
 | Versão | Data       | Modificação                                       | Autor                                                                                                                                   |
 | ------ | ---------- | ------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| 0.1    | 29/07/2021 | Reunião para decidir a priorização dos requisitos | Bruno Félix, Daniel Porto, Edson de Araújo, Eliseu Kadesh, Enzo Gabriel, Francisco Emanoel, João Pedro, Mateus Oliveira e Nilo Mendonça |
+| 0.1    | 29/07/2021 | Reunião para decidir a priorização dos requisitos | Bruno Félix, Daniel Porto, Edson de Araújo, Eliseu Kadesh, Enzo Gabriel, Francisco Emanoel, João Pedro, Mateus Oliveira, Gabriel Bonifácio e Nilo Mendonça |
 | 1.0    | 31/07/2021 | Abertura do documento                             | Eliseu Kadesh                                                                                                                             |

--- a/docs/base/requisitos/priorizacao/first-things-first.md
+++ b/docs/base/requisitos/priorizacao/first-things-first.md
@@ -7,7 +7,7 @@
 
 ## Requisitos Funcionais
 
-&emsp;&emsp;A tabela a seguir detalha e identifica os requisitos funcionais que foram elicitados, seus custos, valor, risco, e também a prioridade baseada no artefato [Moscow](./moscow.md) que também foi realizado pela equipe e que juntamente com o First-Things-First auxilia na priorização dos requisitos.
+&emsp;&emsp;A tabela a seguir detalha e identifica os requisitos funcionais que foram elicitados, seus custos, benefícios, risco, e também a prioridade baseada no artefato [Moscow](./moscow.md) que também foi realizado pela equipe e que juntamente com o First-Things-First auxilia na priorização dos requisitos.
 
 ID | Requisitos | Benefício relativo | Penalidade relativa | Custo relativo | Risco Relativo | Prioridade |
 |--|--|--|--|--|--|--|
@@ -26,6 +26,8 @@ ID | Requisitos | Benefício relativo | Penalidade relativa | Custo relativo | R
 | RF_13 | Professor poder lançar presença.                                                |  7 |   3   |  6  | 4 | 0,344 |
 | RF_14 | Professor poder notificar responsáveis com observações.                         |  7 |   5   |  7  | 3 | 0,463 |
 | -- | TOTAL | 102	| 71,5 | 84,5 | 45 |
+
+[link para a tabela completa no excel](https://docs.google.com/spreadsheets/d/1VO7EnKcoZ7DF_uIbGJHg4b3MkhtVpMwE/edit#gid=667435397)
 
 ## Bibliografia
 

--- a/docs/base/requisitos/priorizacao/first-things-first.md
+++ b/docs/base/requisitos/priorizacao/first-things-first.md
@@ -3,11 +3,11 @@
 
 ## Metodologia
 
-Para a classificação dos benefícios, custo, valor e riscos dos requisitos funcionais, os 10 integrantes do grupo fizeram um debate utilizando a plataforma Microsoft Teams e chegaram a um consenso quanto a priorização de cada requisito.
+&emsp;&emsp;Para a classificação dos benefícios, custo, valor e riscos dos requisitos funcionais, os 10 integrantes do grupo fizeram um debate utilizando a plataforma Microsoft Teams e chegaram a um consenso quanto a priorização de cada requisito.
 
 ## Requisitos Funcionais
 
-A tabela a seguir detalha e identifica os requisitos funcionais que foram elicitados, seus custos, valor, risco, e também a prioridade baseada no artefato [Moscow](./moscow.md) que também foi realizado pela equipe e que juntamente com o First-Things-First auxilia na priorização dos requisitos.
+&emsp;&emsp;A tabela a seguir detalha e identifica os requisitos funcionais que foram elicitados, seus custos, valor, risco, e também a prioridade baseada no artefato [Moscow](./moscow.md) que também foi realizado pela equipe e que juntamente com o First-Things-First auxilia na priorização dos requisitos.
 
 |         | Peso                                                                            | 2                  | 3                 |             |         | 1              |         | 1              |         |            |
 | ------- | ------------------------------------------------------------------------------- | ------------------ | ----------------- | ----------- | ------- | -------------- | ------- | -------------- | ------- | ---------- |
@@ -29,8 +29,9 @@ A tabela a seguir detalha e identifica os requisitos funcionais que foram elicit
 |         | TOTAL                                                                           | 102                | 71,5              | 418,5       | 10,00%  | 84,5           | 100,00% | 45             | 100,00% |            |
 
 
-| Versão | Data       | Modificação                                       | Autor                                                                                                                                   |
-| ------ | ---------- | ------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| 0.1    | 29/07/2021 | Reunião para decidir a priorização dos requisitos | Bruno Félix, Daniel Porto, Edson de Araújo, Eliseu Kadesh, Enzo Gabriel, Francisco Emanoel, João Pedro, Mateus Oliveira, Gabriel Bonifácio e Nilo Mendonça |
-| 1.0    | 31/07/2021 | Abertura do documento | Eliseu Kadesh |
-| 1.1    | 03/07/2021 | Padronização do documento | Eliseu Kadesh |
+
+| Versão | Data | Modificação | Autor | 
+|--|--|--|--|
+| 0.1 | 29/07/2021 | Reunião para decidir a priorização dos requisitos | Bruno Félix, Daniel Porto, Edson de Araújo, Eliseu Kadesh, Enzo Gabriel, Francisco Emanoel, João Pedro, Mateus Oliveira, Gabriel Bonifácio e Nilo Mendonça |
+| 1.0 | 31/07/2021 | Abertura do documento | Eliseu Kadesh |
+| 1.1 | 03/07/2021 | Padronização do documento | Eliseu Kadesh |

--- a/docs/base/requisitos/priorizacao/first-things-first.md
+++ b/docs/base/requisitos/priorizacao/first-things-first.md
@@ -28,7 +28,7 @@
 | RF_14 | Professor poder notificar responsáveis com observações.                         | 7                  | 5                 | 29          | 6,93%   | 7              | 8,28%   | 3              | 6,67%   | 0,463      |
 |         | TOTAL                                                                           | 102                | 71,5              | 418,5       | 10,00%  | 84,5           | 100,00% | 45             | 100,00% |            |
 
-
+## Versionamento
 
 | Versão | Data | Modificação | Autor | 
 |--|--|--|--|

--- a/docs/base/requisitos/priorizacao/first-things-first.md
+++ b/docs/base/requisitos/priorizacao/first-things-first.md
@@ -11,20 +11,20 @@
 
 ID | Requisitos | Benefício relativo | Penalidade relativa | Custo relativo | Risco Relativo | Prioridade |
 |--|--|--|--|--|--|--|
-| RF_01 | Ter sistema de comunicação entre responsáveis e professores.                    | 6,5	|   5   |  8  | 4 | 0,364 |
-| RF_02 | Ter sistema de comunicação entre responsáveis e administradores da instituição. | 4,5	  |   3   |  8  | 5 | 0,209 |
-| RF_03 | Responsáveis receberem notificações sobre novas atividades.                     |  7	|   2   |  4  | 5 | 0,302 |
-| RF_04 | Responsáveis receberem notificações sobre entrada e saída da crianças.          |  6  |   2   | 8,5 | 7 | 0,268 |
+| RF_01 | Ter sistema de comunicação entre responsáveis e professores.                    | 6,5 |   5   |  8  | 4 | 0,364 |
+| RF_02 | Ter sistema de comunicação entre responsáveis e administradores da instituição. | 4,5 |   3   |  8  | 5 | 0,209 |
+| RF_03 | Responsáveis receberem notificações sobre novas atividades.                     |  7 |   2   |  4  | 5 | 0,302 |
+| RF_04 | Responsáveis receberem notificações sobre entrada e saída da crianças.          |  6 |   2   | 8,5 | 7 | 0,268 |
 | RF_05 | Responsáveis receberem notificações sobre novos eventos.                        |  6  |  1,5  |  4  | 5 | 0,249 |
-| RF_06 | Administrador poder criar e configurar turmas.                                  |  9	|   9   |  6  | 1 | 1,153 |
-| RF_07 | Administrador poder registras as crianças.                                      |  9  |   9   |  4  | 1 | 1,546 |
-| RF_08 | Administrador poder registrar os professores.                                   |  9  |   9   |  4  | 1 | 1,546 |
-| RF_09 | Administrador poder criar e configurar eventos.                                 |  7	|   3   |  6  | 3 | 0,399 |
-| RF_10 | Poder disponibilizar relatórios gerais.                                         |  6	|   3   |  6  | 4 | 0,314 |
-| RF_11 | Responsáveis terem acesso as informações e dados de suas crianças.              |  9	|   9   |  7  | 1 | 1,023 |
-| RF_12 | Professor poder registrar e gerenciar atividades.                               |  9	|   8   |  6  | 1 | 1,076 |
-| RF_13 | Professor poder lançar presença.                                                |  7	|   3   |  6  | 4 | 0,344 |
-| RF_14 | Professor poder notificar responsáveis com observações.                         |  7	|   5   |  7  | 3 | 0,463 |
+| RF_06 | Administrador poder criar e configurar turmas.                                  |  9 |   9   |  6  | 1 | 1,153 |
+| RF_07 | Administrador poder registras as crianças.                                      |  9 |   9   |  4  | 1 | 1,546 |
+| RF_08 | Administrador poder registrar os professores.                                   |  9 |   9   |  4  | 1 | 1,546 |
+| RF_09 | Administrador poder criar e configurar eventos.                                 |  7 |   3   |  6  | 3 | 0,399 |
+| RF_10 | Poder disponibilizar relatórios gerais.                                         |  6 |   3   |  6  | 4 | 0,314 |
+| RF_11 | Responsáveis terem acesso as informações e dados de suas crianças.              |  9 |   9   |  7  | 1 | 1,023 |
+| RF_12 | Professor poder registrar e gerenciar atividades.                               |  9 |   8   |  6  | 1 | 1,076 |
+| RF_13 | Professor poder lançar presença.                                                |  7 |   3   |  6  | 4 | 0,344 |
+| RF_14 | Professor poder notificar responsáveis com observações.                         |  7 |   5   |  7  | 3 | 0,463 |
 | -- | TOTAL | 102	| 71,5 | 84,5 | 45 |
 
 ## Versionamento

--- a/docs/base/requisitos/priorizacao/first-things-first.md
+++ b/docs/base/requisitos/priorizacao/first-things-first.md
@@ -3,29 +3,33 @@
 
 ## Metodologia
 
-&emsp;&emsp;Para a classificação dos benefícios, custo, valor e riscos dos requisitos funcionais, os 10 integrantes do grupo fizeram um debate utilizando a plataforma Microsoft Teams e chegaram a um consenso quanto a priorização de cada requisito.
+&emsp;&emsp;Para a classificação dos benefícios, custo, valor e riscos dos requisitos funcionais, os 10 integrantes do grupo fizeram um debate utilizando a plataforma Microsoft Teams e chegaram a um consenso quanto a priorização de cada requisito.<br>
+&emsp;&emsp;Os cálculos dessa técnica são dados de forma que:
+
+- O valor total é a soma (Benefício Relativo * Peso Relativo + Penalidade Relativa * Peso Relativo);
+- A prioridade de cada requisito é igual ao valor total % / (custo % * Peso custo + risco % * Peso Risco).
+
 
 ## Requisitos Funcionais
 
 &emsp;&emsp;A tabela a seguir detalha e identifica os requisitos funcionais que foram elicitados, seus custos, benefícios, risco, e também a prioridade baseada no artefato [Moscow](./moscow.md) que também foi realizado pela equipe e que juntamente com o First-Things-First auxilia na priorização dos requisitos.
 
-ID | Requisitos | Benefício relativo | Penalidade relativa | Custo relativo | Risco Relativo | Prioridade |
-|--|--|--|--|--|--|--|
-| RF_01 | Ter sistema de comunicação entre responsáveis e professores.                    | 6,5 |   5   |  8  | 4 | 0,364 |
-| RF_02 | Ter sistema de comunicação entre responsáveis e administradores da instituição. | 4,5 |   3   |  8  | 5 | 0,209 |
-| RF_03 | Responsáveis receberem notificações sobre novas atividades.                     |  7 |   2   |  4  | 5 | 0,302 |
-| RF_04 | Responsáveis receberem notificações sobre entrada e saída da crianças.          |  6 |   2   | 8,5 | 7 | 0,268 |
-| RF_05 | Responsáveis receberem notificações sobre novos eventos.                        |  6  |  1,5  |  4  | 5 | 0,249 |
-| RF_06 | Administrador poder criar e configurar turmas.                                  |  9 |   9   |  6  | 1 | 1,153 |
-| RF_07 | Administrador poder registras as crianças.                                      |  9 |   9   |  4  | 1 | 1,546 |
-| RF_08 | Administrador poder registrar os professores.                                   |  9 |   9   |  4  | 1 | 1,546 |
-| RF_09 | Administrador poder criar e configurar eventos.                                 |  7 |   3   |  6  | 3 | 0,399 |
-| RF_10 | Poder disponibilizar relatórios gerais.                                         |  6 |   3   |  6  | 4 | 0,314 |
-| RF_11 | Responsáveis terem acesso as informações e dados de suas crianças.              |  9 |   9   |  7  | 1 | 1,023 |
-| RF_12 | Professor poder registrar e gerenciar atividades.                               |  9 |   8   |  6  | 1 | 1,076 |
-| RF_13 | Professor poder lançar presença.                                                |  7 |   3   |  6  | 4 | 0,344 |
-| RF_14 | Professor poder notificar responsáveis com observações.                         |  7 |   5   |  7  | 3 | 0,463 |
-| -- | TOTAL | 102	| 71,5 | 84,5 | 45 |
+ID | Requisitos | Prioridade |
+|--|--|--|
+| **RF_01** | Ter sistema de comunicação entre responsáveis e professores.                    | 0,364 |
+| **RF_02** | Ter sistema de comunicação entre responsáveis e administradores da instituição. | 0,209 |
+| **RF_03** | Responsáveis receberem notificações sobre novas atividades.                     |0,302 |
+| **RF_04** | Responsáveis receberem notificações sobre entrada e saída da crianças.          |0,268 |
+| **RF_05** | Responsáveis receberem notificações sobre novos eventos.                        | 0,249 |
+| **RF_06** | Administrador poder criar e configurar turmas.                                  |1,153 |
+| **RF_07** | Administrador poder registras as crianças.                                      |1,546 |
+| **RF_08** | Administrador poder registrar os professores.                                   |1,546 |
+| **RF_09** | Administrador poder criar e configurar eventos.                                 |0,399 |
+| **RF_10** | Poder disponibilizar relatórios gerais.                                         |0,314 |
+| **RF_11** | Responsáveis terem acesso as informações e dados de suas crianças.              |1,023 |
+| **RF_12** | Professor poder registrar e gerenciar atividades.                               |1,076 |
+| **RF_13** | Professor poder lançar presença.                                                |0,344 |
+| **RF_14** | Professor poder notificar responsáveis com observações.                         |0,463 |
 
 [link para a tabela completa no excel](https://docs.google.com/spreadsheets/d/1VO7EnKcoZ7DF_uIbGJHg4b3MkhtVpMwE/edit#gid=667435397)
 
@@ -39,5 +43,6 @@ ID | Requisitos | Benefício relativo | Penalidade relativa | Custo relativo | R
 |--|--|--|--|
 | 0.1 | 29/07/2021 | Reunião para decidir a priorização dos requisitos | Bruno Félix, Daniel Porto, Edson de Araújo, Eliseu Kadesh, Enzo Gabriel, Francisco Emanoel, João Pedro, Mateus Oliveira, Gabriel Bonifácio e Nilo Mendonça |
 | 1.0 | 31/07/2021 | Abertura do documento | Eliseu Kadesh |
-| 1.1 | 03/07/2021 | Padronização do documento | Eliseu Kadesh |
-| 2.0 | 05/07/2021 | Finalização da padronização do documento | Eliseu Kadesh |
+| 1.1 | 03/08/2021 | Padronização do documento | Eliseu Kadesh |
+| 2.0 | 05/08/2021 | Finalização da padronização do documento | Eliseu Kadesh |
+| 2.1 | 06/08/2021 | Correções após revisões | Daniel Porto |

--- a/docs/base/requisitos/priorizacao/first-things-first.md
+++ b/docs/base/requisitos/priorizacao/first-things-first.md
@@ -32,4 +32,5 @@ A tabela a seguir detalha e identifica os requisitos funcionais que foram elicit
 | Versão | Data       | Modificação                                       | Autor                                                                                                                                   |
 | ------ | ---------- | ------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
 | 0.1    | 29/07/2021 | Reunião para decidir a priorização dos requisitos | Bruno Félix, Daniel Porto, Edson de Araújo, Eliseu Kadesh, Enzo Gabriel, Francisco Emanoel, João Pedro, Mateus Oliveira, Gabriel Bonifácio e Nilo Mendonça |
-| 1.0    | 31/07/2021 | Abertura do documento                             | Eliseu Kadesh                                                                                                                             |
+| 1.0    | 31/07/2021 | Abertura do documento | Eliseu Kadesh |
+| 1.1    | 03/07/2021 | Padronização do documento | Eliseu Kadesh |

--- a/docs/base/requisitos/priorizacao/first-things-first.md
+++ b/docs/base/requisitos/priorizacao/first-things-first.md
@@ -13,18 +13,18 @@ ID | Requisitos | Benefício relativo | Penalidade relativa | Custo relativo | R
 |--|--|--|--|--|--|--|
 | RF_01 | Ter sistema de comunicação entre responsáveis e professores.                    | 6,5	|5 | 8 | 4 | 0,364 |
 | RF_02 | Ter sistema de comunicação entre responsáveis e administradores da instituição. | 4,5	|3 | 8 | 5 | 0,209 |
-| RF_03 | Responsáveis receberem notificações sobre novas atividades.                     | 7	|  2 | 4 | 5	| 0,302 |
-| RF_04 | Responsáveis receberem notificações sobre entrada e saída da crianças.          | 6	|  2 | 8,5 | 7 | 0,268 |
-| RF_05 | Responsáveis receberem notificações sobre novos eventos.                        | 6	|  1,5 | 4 | 5 | 0,249 |
-| RF_06 | Administrador poder criar e configurar turmas.                                  | 9	|  9 | 6 | 1 | 1,153 |
-| RF_07 | Administrador poder registras as crianças.                                      | 9	|  9 | 4 | 1 | 1,546 |
-| RF_08 | Administrador poder registrar os professores.                                   | 9	|  9 | 4 | 1 | 1,546 |
-| RF_09 | Administrador poder criar e configurar eventos.                                 | 7	|  3 | 6 | 3 | 0,399 |
-| RF_10 | Poder disponibilizar relatórios gerais.                                         | 6	|  3 | 6 | 4 | 0,314 |
-| RF_11 | Responsáveis terem acesso as informações e dados de suas crianças.              | 9	|  9 | 7 | 1 | 1,023 |
-| RF_12 | Professor poder registrar e gerenciar atividades.                               | 9	|  8 | 6 | 1 | 1,076 |
-| RF_13 | Professor poder lançar presença.                                                | 7	|  3 | 6 | 4 | 0,344 |
-| RF_14 | Professor poder notificar responsáveis com observações.                         | 7	|  5 | 7 | 3 | 0,463 |
+| RF_03 | Responsáveis receberem notificações sobre novas atividades.                     |  7	| 2 |  4  | 5	| 0,302 |
+| RF_04 | Responsáveis receberem notificações sobre entrada e saída da crianças.          |  6  | 2   | 8,5 | 7 | 0,268 |
+| RF_05 | Responsáveis receberem notificações sobre novos eventos.                        |  6  | 1,5 |  4  | 5 | 0,249 |
+| RF_06 | Administrador poder criar e configurar turmas.                                  |  9	| 9   |  6  | 1 | 1,153 |
+| RF_07 | Administrador poder registras as crianças.                                      |  9  |9   |  4  | 1 | 1,546 |
+| RF_08 | Administrador poder registrar os professores.                                   |  9  | 9   |  4  | 1 | 1,546 |
+| RF_09 | Administrador poder criar e configurar eventos.                                 |  7	| 3   |  6  | 3 | 0,399 |
+| RF_10 | Poder disponibilizar relatórios gerais.                                         |  6	| 3   |  6  | 4 | 0,314 |
+| RF_11 | Responsáveis terem acesso as informações e dados de suas crianças.              |  9	| 9   |  7  | 1 | 1,023 |
+| RF_12 | Professor poder registrar e gerenciar atividades.                               |  9	| 8   |  6  | 1 | 1,076 |
+| RF_13 | Professor poder lançar presença.                                                |  7	| 3   |  6  | 4 | 0,344 |
+| RF_14 | Professor poder notificar responsáveis com observações.                         |  7	| 5   |  7  | 3 | 0,463 |
 | -- | TOTAL | 102	| 71,5 | 84,5 | 45 |
 
 ## Versionamento

--- a/docs/base/requisitos/priorizacao/first-things-first.md
+++ b/docs/base/requisitos/priorizacao/first-things-first.md
@@ -11,20 +11,20 @@
 
 ID | Requisitos | Benefício relativo | Penalidade relativa | Custo relativo | Risco Relativo | Prioridade |
 |--|--|--|--|--|--|--|
-| RF_01 | Ter sistema de comunicação entre responsáveis e professores.                    | 6,5	|5 | 8 | 4 | 0,364 |
-| RF_02 | Ter sistema de comunicação entre responsáveis e administradores da instituição. | 4,5	|3 | 8 | 5 | 0,209 |
-| RF_03 | Responsáveis receberem notificações sobre novas atividades.                     |  7	| 2 |  4  | 5	| 0,302 |
-| RF_04 | Responsáveis receberem notificações sobre entrada e saída da crianças.          |  6  | 2   | 8,5 | 7 | 0,268 |
-| RF_05 | Responsáveis receberem notificações sobre novos eventos.                        |  6  | 1,5 |  4  | 5 | 0,249 |
-| RF_06 | Administrador poder criar e configurar turmas.                                  |  9	| 9   |  6  | 1 | 1,153 |
+| RF_01 | Ter sistema de comunicação entre responsáveis e professores.                    | 6,5	|5   |  8  | 4 | 0,364 |
+| RF_02 | Ter sistema de comunicação entre responsáveis e administradores da instituição. | 4,5	|3   |  8  | 5 | 0,209 |
+| RF_03 | Responsáveis receberem notificações sobre novas atividades.                     |  7	|2   |  4  | 5 | 0,302 |
+| RF_04 | Responsáveis receberem notificações sobre entrada e saída da crianças.          |  6  |2   | 8,5 | 7 | 0,268 |
+| RF_05 | Responsáveis receberem notificações sobre novos eventos.                        |  6  |1,5 |  4  | 5 | 0,249 |
+| RF_06 | Administrador poder criar e configurar turmas.                                  |  9	|9   |  6  | 1 | 1,153 |
 | RF_07 | Administrador poder registras as crianças.                                      |  9  |9   |  4  | 1 | 1,546 |
-| RF_08 | Administrador poder registrar os professores.                                   |  9  | 9   |  4  | 1 | 1,546 |
-| RF_09 | Administrador poder criar e configurar eventos.                                 |  7	| 3   |  6  | 3 | 0,399 |
-| RF_10 | Poder disponibilizar relatórios gerais.                                         |  6	| 3   |  6  | 4 | 0,314 |
-| RF_11 | Responsáveis terem acesso as informações e dados de suas crianças.              |  9	| 9   |  7  | 1 | 1,023 |
-| RF_12 | Professor poder registrar e gerenciar atividades.                               |  9	| 8   |  6  | 1 | 1,076 |
-| RF_13 | Professor poder lançar presença.                                                |  7	| 3   |  6  | 4 | 0,344 |
-| RF_14 | Professor poder notificar responsáveis com observações.                         |  7	| 5   |  7  | 3 | 0,463 |
+| RF_08 | Administrador poder registrar os professores.                                   |  9  |9   |  4  | 1 | 1,546 |
+| RF_09 | Administrador poder criar e configurar eventos.                                 |  7	|3   |  6  | 3 | 0,399 |
+| RF_10 | Poder disponibilizar relatórios gerais.                                         |  6	|3   |  6  | 4 | 0,314 |
+| RF_11 | Responsáveis terem acesso as informações e dados de suas crianças.              |  9	|9   |  7  | 1 | 1,023 |
+| RF_12 | Professor poder registrar e gerenciar atividades.                               |  9	|8   |  6  | 1 | 1,076 |
+| RF_13 | Professor poder lançar presença.                                                |  7	|3   |  6  | 4 | 0,344 |
+| RF_14 | Professor poder notificar responsáveis com observações.                         |  7	|5   |  7  | 3 | 0,463 |
 | -- | TOTAL | 102	| 71,5 | 84,5 | 45 |
 
 ## Versionamento

--- a/docs/base/requisitos/priorizacao/first-things-first.md
+++ b/docs/base/requisitos/priorizacao/first-things-first.md
@@ -11,20 +11,20 @@
 
 ID | Requisitos | Benefício relativo | Penalidade relativa | Custo relativo | Risco Relativo | Prioridade |
 |--|--|--|--|--|--|--|
-| RF_01 | Ter sistema de comunicação entre responsáveis e professores.                    | 6,5	|5   |  8  | 4 | 0,364 |
-| RF_02 | Ter sistema de comunicação entre responsáveis e administradores da instituição. | 4,5	|3   |  8  | 5 | 0,209 |
-| RF_03 | Responsáveis receberem notificações sobre novas atividades.                     |  7	|2   |  4  | 5 | 0,302 |
-| RF_04 | Responsáveis receberem notificações sobre entrada e saída da crianças.          |  6  |2   | 8,5 | 7 | 0,268 |
-| RF_05 | Responsáveis receberem notificações sobre novos eventos.                        |  6  |1,5 |  4  | 5 | 0,249 |
-| RF_06 | Administrador poder criar e configurar turmas.                                  |  9	|9   |  6  | 1 | 1,153 |
-| RF_07 | Administrador poder registras as crianças.                                      |  9  |9   |  4  | 1 | 1,546 |
-| RF_08 | Administrador poder registrar os professores.                                   |  9  |9   |  4  | 1 | 1,546 |
-| RF_09 | Administrador poder criar e configurar eventos.                                 |  7	|3   |  6  | 3 | 0,399 |
-| RF_10 | Poder disponibilizar relatórios gerais.                                         |  6	|3   |  6  | 4 | 0,314 |
-| RF_11 | Responsáveis terem acesso as informações e dados de suas crianças.              |  9	|9   |  7  | 1 | 1,023 |
-| RF_12 | Professor poder registrar e gerenciar atividades.                               |  9	|8   |  6  | 1 | 1,076 |
-| RF_13 | Professor poder lançar presença.                                                |  7	|3   |  6  | 4 | 0,344 |
-| RF_14 | Professor poder notificar responsáveis com observações.                         |  7	|5   |  7  | 3 | 0,463 |
+| RF_01 | Ter sistema de comunicação entre responsáveis e professores.                    | 6,5	|   5   |  8  | 4 | 0,364 |
+| RF_02 | Ter sistema de comunicação entre responsáveis e administradores da instituição. | 4,5	  |   3   |  8  | 5 | 0,209 |
+| RF_03 | Responsáveis receberem notificações sobre novas atividades.                     |  7	|   2   |  4  | 5 | 0,302 |
+| RF_04 | Responsáveis receberem notificações sobre entrada e saída da crianças.          |  6  |   2   | 8,5 | 7 | 0,268 |
+| RF_05 | Responsáveis receberem notificações sobre novos eventos.                        |  6  |  1,5  |  4  | 5 | 0,249 |
+| RF_06 | Administrador poder criar e configurar turmas.                                  |  9	|   9   |  6  | 1 | 1,153 |
+| RF_07 | Administrador poder registras as crianças.                                      |  9  |   9   |  4  | 1 | 1,546 |
+| RF_08 | Administrador poder registrar os professores.                                   |  9  |   9   |  4  | 1 | 1,546 |
+| RF_09 | Administrador poder criar e configurar eventos.                                 |  7	|   3   |  6  | 3 | 0,399 |
+| RF_10 | Poder disponibilizar relatórios gerais.                                         |  6	|   3   |  6  | 4 | 0,314 |
+| RF_11 | Responsáveis terem acesso as informações e dados de suas crianças.              |  9	|   9   |  7  | 1 | 1,023 |
+| RF_12 | Professor poder registrar e gerenciar atividades.                               |  9	|   8   |  6  | 1 | 1,076 |
+| RF_13 | Professor poder lançar presença.                                                |  7	|   3   |  6  | 4 | 0,344 |
+| RF_14 | Professor poder notificar responsáveis com observações.                         |  7	|   5   |  7  | 3 | 0,463 |
 | -- | TOTAL | 102	| 71,5 | 84,5 | 45 |
 
 ## Versionamento

--- a/docs/base/requisitos/priorizacao/first-things-first.md
+++ b/docs/base/requisitos/priorizacao/first-things-first.md
@@ -27,6 +27,10 @@ ID | Requisitos | Benefício relativo | Penalidade relativa | Custo relativo | R
 | RF_14 | Professor poder notificar responsáveis com observações.                         |  7 |   5   |  7  | 3 | 0,463 |
 | -- | TOTAL | 102	| 71,5 | 84,5 | 45 |
 
+## Bibliografia
+
+> - E. WIEGERS, Karl. 1999. First Things First: Prioritizing Requirements.
+
 ## Versionamento
 
 | Versão | Data | Modificação | Autor | 

--- a/docs/base/requisitos/priorizacao/first-things-first.md
+++ b/docs/base/requisitos/priorizacao/first-things-first.md
@@ -40,3 +40,4 @@ ID | Requisitos | Benefício relativo | Penalidade relativa | Custo relativo | R
 | 0.1 | 29/07/2021 | Reunião para decidir a priorização dos requisitos | Bruno Félix, Daniel Porto, Edson de Araújo, Eliseu Kadesh, Enzo Gabriel, Francisco Emanoel, João Pedro, Mateus Oliveira, Gabriel Bonifácio e Nilo Mendonça |
 | 1.0 | 31/07/2021 | Abertura do documento | Eliseu Kadesh |
 | 1.1 | 03/07/2021 | Padronização do documento | Eliseu Kadesh |
+| 2.0 | 05/07/2021 | Finalização da padronização do documento | Eliseu Kadesh |

--- a/docs/base/requisitos/priorizacao/first-things-first.md
+++ b/docs/base/requisitos/priorizacao/first-things-first.md
@@ -9,24 +9,23 @@
 
 &emsp;&emsp;A tabela a seguir detalha e identifica os requisitos funcionais que foram elicitados, seus custos, valor, risco, e também a prioridade baseada no artefato [Moscow](./moscow.md) que também foi realizado pela equipe e que juntamente com o First-Things-First auxilia na priorização dos requisitos.
 
-|         | Peso                                                                            | 2                  | 3                 |             |         | 1              |         | 1              |         |            |
-| ------- | ------------------------------------------------------------------------------- | ------------------ | ----------------- | ----------- | ------- | -------------- | ------- | -------------- | ------- | ---------- |
-| ID      | Requisitos                                                                      | Benefício relativo | Penalidade relativa | Valor Total | Valor % | Custo relativo | Custo % | Risco Relativo | Risco % | Prioridade |
-| RF_01 | Ter sistema de comunicação entre responsáveis e professores.                    | 6,5                | 5                 | 28          | 6,69%   | 8              | 9,47%   | 4              | 8,89%   | 0,364      |
-| RF_02 | Ter sistema de comunicação entre responsáveis e administradores da instituição. | 4,5                | 3                 | 18          | 4,30%   | 8              | 9,47%   | 5              | 11,11%  | 0,209      |
-| RF_03 | Responsáveis receberem notificações sobre novas atividades.                     | 7                  | 2                 | 20          | 4,78%   | 4              | 4,73%   | 5              | 11,11%  | 0,302      |
-| RF_04 | Responsáveis receberem notificações sobre entrada e saída da crianças.          | 6                  | 2                 | 18          | 4,30%   | 8,5            | 10,06%  | 7              | 15,56%  | 0,268      |
-| RF_05 | Responsáveis receberem notificações sobre novos eventos.                        | 6                  | 1,5               | 16,5        | 3,94%   | 4              | 4,73%   | 5              | 11,11%  | 0,249      |
-| RF_06 | Administrador poder criar e configurar turmas.                                  | 9                  | 9                 | 45          | 10,75%  | 6              | 7,10%   | 1              | 2,22%   | 1,153      |
-| RF_07 | Administrador poder registras as crianças.                                      | 9                  | 9                 | 45          | 10,75%  | 4              | 4,73%   | 1              | 2,22%   | 1,546      |
-| RF_08 | Administrador poder registrar os professores.                                   | 9                  | 9                 | 45          | 10,75%  | 4              | 4,73%   | 1              | 2,22%   | 1,546      |
-| RF_09 | Administrador poder criar e configurar eventos.                                 | 7                  | 3                 | 23          | 5,50%   | 6              | 7,10%   | 3              | 6,67%   | 0,399      |
-| RF_10 | Poder disponibilizar relatórios gerais.                                         | 6                  | 3                 | 21          | 5,02%   | 6              | 7,10%   | 4              | 8,89%   | 0,314      |
-| RF_11 | Responsáveis terem acesso as informações e dados de suas crianças.             | 9                  | 9                 | 45          | 10,75%  | 7              | 8,28%   | 1              | 2,22%   | 1,023      |
-| RF_12 | Professor poder registrar e gerenciar atividades.                                | 9                  | 8                 | 42          | 10,04%  | 6              | 7,10%   | 1              | 2,22%   | 1,076      |
-| RF_13 | Professor poder lançar presença.                                                | 7                  | 3                 | 23          | 5,50%   | 6              | 7,10%   | 4              | 8,89%   | 0,344      |
-| RF_14 | Professor poder notificar responsáveis com observações.                         | 7                  | 5                 | 29          | 6,93%   | 7              | 8,28%   | 3              | 6,67%   | 0,463      |
-|         | TOTAL                                                                           | 102                | 71,5              | 418,5       | 10,00%  | 84,5           | 100,00% | 45             | 100,00% |            |
+ID | Requisitos | Benefício relativo | Penalidade relativa | Custo relativo | Risco Relativo | Prioridade |
+|--|--|--|--|--|--|--|
+| RF_01 | Ter sistema de comunicação entre responsáveis e professores.                    | 6,5	|5 | 8 | 4 | 0,364 |
+| RF_02 | Ter sistema de comunicação entre responsáveis e administradores da instituição. | 4,5	|3 | 8 | 5 | 0,209 |
+| RF_03 | Responsáveis receberem notificações sobre novas atividades.                     | 7	|  2 | 4 | 5	| 0,302 |
+| RF_04 | Responsáveis receberem notificações sobre entrada e saída da crianças.          | 6	|  2 | 8,5 | 7 | 0,268 |
+| RF_05 | Responsáveis receberem notificações sobre novos eventos.                        | 6	|  1,5 | 4 | 5 | 0,249 |
+| RF_06 | Administrador poder criar e configurar turmas.                                  | 9	|  9 | 6 | 1 | 1,153 |
+| RF_07 | Administrador poder registras as crianças.                                      | 9	|  9 | 4 | 1 | 1,546 |
+| RF_08 | Administrador poder registrar os professores.                                   | 9	|  9 | 4 | 1 | 1,546 |
+| RF_09 | Administrador poder criar e configurar eventos.                                 | 7	|  3 | 6 | 3 | 0,399 |
+| RF_10 | Poder disponibilizar relatórios gerais.                                         | 6	|  3 | 6 | 4 | 0,314 |
+| RF_11 | Responsáveis terem acesso as informações e dados de suas crianças.              | 9	|  9 | 7 | 1 | 1,023 |
+| RF_12 | Professor poder registrar e gerenciar atividades.                               | 9	|  8 | 6 | 1 | 1,076 |
+| RF_13 | Professor poder lançar presença.                                                | 7	|  3 | 6 | 4 | 0,344 |
+| RF_14 | Professor poder notificar responsáveis com observações.                         | 7	|  5 | 7 | 3 | 0,463 |
+| -- | TOTAL | 102	| 71,5 | 84,5 | 45 |
 
 ## Versionamento
 


### PR DESCRIPTION
## Descrição

Atualiza o documeto de First Things First, adicionando texto informativo antes da tabela, corrigindo o ID dos requisitos e padroniza melhor o documento.

## _Issue_ Relacionada
#15 