### PR TITLE
Rótulo de iniciativa extra

### DIFF
--- a/docs/assets/stylesheets/extra.css
+++ b/docs/assets/stylesheets/extra.css
@@ -61,3 +61,11 @@ body{
     width: auto; 
     text-decoration: none;
 }
+
+.rotulo-extra{
+    background-color: #3f6ec6;
+    color:#ffffff;
+    border-radius: 4px;
+    padding: 7px;
+    font-size: 20px;
+}

--- a/docs/base/design-sprint/plan-test.md
+++ b/docs/base/design-sprint/plan-test.md
@@ -1,4 +1,4 @@
-# Planejamento da Avaliação do [Protótipo de alta fidelidade](/base/requisitos/modelagem/lexicos/#lexico-prototipo-de-alta-fidelidade)
+# Planejamento da Avaliação do [Protótipo de alta fidelidade](/base/requisitos/modelagem/lexicos/#lexico-prototipo-de-alta-fidelidade) <br> <span class="rotulo-extra">Iniciativa Extra</span>
 
 ## Introdução
 &emsp;&emsp;O presente documento visa o planejamento da avaliação a partir do teste de usabilidade do [protótipo de alta fidelidade](/base/requisitos/modelagem/lexicos/#lexico-prototipo-de-alta-fidelidade) desenvolvido pela equipe.

--- a/docs/base/requisitos/elicitacao/introspeccao.md
+++ b/docs/base/requisitos/elicitacao/introspeccao.md
@@ -1,3 +1,5 @@
+# Introspecção <br> <span class="rotulo-extra">Iniciativa Extra</span>
+
 ## Introdução
 &emsp;&emsp;A introspecção é uma técnica de elicitação de requisitos, baseando-se na ideia de buscar entender qual é o tipo de sistema a persona gostaria de ter (e ver) quando estivesse executando uma tarefa desejada na aplicação. Para isso, portanto, criamos as [personas](./personas.md) com o intuito de utilizar essa técnica.
 

--- a/docs/base/requisitos/elicitacao/personas.md
+++ b/docs/base/requisitos/elicitacao/personas.md
@@ -1,3 +1,5 @@
+# Personas <br> <span class="rotulo-extra">Iniciativa Extra</span>
+
 ## Introdução
 &emsp;&emsp;
 Uma persona é um personagem fictício, arquétipo hipotético de um grupo de [usuários](../../modelagem/lexicos/#lexico-usuario) reais, criada para descrever um [usuário](../../modelagem/lexicos/#lexico-usuario) típico (Cooper et al., 2007; Pruitt e Adlin, 2006; Cooper, 1999).

--- a/docs/base/requisitos/modelagem/especificacao-suplementar.md
+++ b/docs/base/requisitos/modelagem/especificacao-suplementar.md
@@ -1,3 +1,5 @@
+#Especificação Suplementar <br> <span class="rotulo-extra">Iniciativa Extra</span>
+
 ### Introdução
 
 <p style="text-indent: 20px; text-align: justify">

--- a/docs/base/requisitos/modelagem/i-star.md
+++ b/docs/base/requisitos/modelagem/i-star.md
@@ -1,4 +1,5 @@
-# iStar
+
+# iStar <br> <span class="rotulo-extra">Iniciativa Extra</span>
 
 ## Introdução
 

--- a/docs/base/requisitos/modelagem/lexicos.md
+++ b/docs/base/requisitos/modelagem/lexicos.md
@@ -1,4 +1,4 @@
-# Léxicos
+# Léxicos <br> <span class="rotulo-extra">Iniciativa Extra</span>
 
 ## Introdução
 

--- a/docs/base/requisitos/modelagem/nfr-framework.md
+++ b/docs/base/requisitos/modelagem/nfr-framework.md
@@ -1,3 +1,5 @@
+# NFR Framework <br> <span class="rotulo-extra">Iniciativa Extra</span>
+
 ## Introdução
 &emsp;&emsp;Requisitos não funcionais em um sistema de software não descrevem o que o software irá fazer, mas como o software irá fazer, levando em consideração características que não são funcionais, como performance, requisitos de interface, design e qualidade(CHUNG et al, 2012).
 

--- a/docs/base/requisitos/pre-rastreabilidade/argumentacao.md
+++ b/docs/base/requisitos/pre-rastreabilidade/argumentacao.md
@@ -1,3 +1,5 @@
+# Argumentação <br> <span class="rotulo-extra">Iniciativa Extra</span>
+
 ## Introdução
 &emsp;&emsp;A argumentação pode ser caracterizada como uma forma vital da cognição humana, representando assim uma atividade de comunicação essencial para a sociedade.
 

--- a/docs/base/requisitos/priorizacao/first-things-first.md
+++ b/docs/base/requisitos/priorizacao/first-things-first.md
@@ -1,3 +1,4 @@
+# First Things First <br> <span class="rotulo-extra">Iniciativa Extra</span>
 ## Introdução
 &emsp;&emsp;O First-Things-First é uma técnica de priorização utilizada baseada em custo, valor e risco dos requisitos de um projeto.
 

--- a/docs/base/tap/tap.md
+++ b/docs/base/tap/tap.md
@@ -1,4 +1,4 @@
-# Termo de abertura do projeto (TAP)
+# Termo de abertura do projeto (TAP) <br> <span class="rotulo-extra">Iniciativa Extra</span>
  
 ## 1. Introdução
  

--- a/docs/guia-contrib.md
+++ b/docs/guia-contrib.md
@@ -1,3 +1,5 @@
+# Guia de Contribuição <br> <span class="rotulo-extra">Iniciativa Extra</span>
+
 ## O que fazer antes de começar a contribuir?
 &emsp;&emsp;É de suma importância que, antes de começar a comtribuir, conheça bem o projeto e seus padrões. Por isso, é aconselhado que realize os seguintes passos:
 

--- a/docs/politicas.md
+++ b/docs/politicas.md
@@ -1,4 +1,4 @@
-# Políticas de Contribuição
+# Políticas de Contribuição <br> <span class="rotulo-extra">Iniciativa Extra</span>
 
 ## Introdução
 &emsp;&emsp;O presente documento visa apresentar as políticas que serão usadas no decorrer do projeto, detalhando as politicas de branchs e seu fluxo de trabalho, commits, issues e pull requests.


### PR DESCRIPTION
## Descrição
<!--- Decreva suas alterações detalhadamente -->
Foi Criado a classe "rotulo-extra" no css da wiki para identificar os artefatos nessa situação.
A utilização dessa classe deve ser feita em uma tag span logo no título do documento após uma quebra de linha
Dessa forma:
`# Titulo Do Documento <br> <span class="rotulo-extra">Iniciativa Extra</span>`

## _Issue_ Relacionada
<!--- Este projeto apenas aceita _pull requests_ relacionadas à _issues_ abertas. -->
<!--- Por favor, adicione o link para a _issue_ aqui: -->
Closes #51 